### PR TITLE
Update workflow to use new wrapping image in GHCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,9 +71,8 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-            # Temporary: dockerRepository will change to ghcr.io once the Wrapping image is available there
           build-args: |
-            dockerRepository=harbor.galasa.dev
+            dockerRepository=ghcr.io
             tag=${{ env.BRANCH }}
 
       # Recycle the development Maven registry app in ArgoCD

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -57,7 +57,6 @@ jobs:
           push: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          # dockerRepository will change to ghcr.io once the Wrapping image is available there
           build-args: |
-            dockerRepository=harbor.galasa.dev
+            dockerRepository=ghcr.io
             tag=main

--- a/dockerfiles/dockerfile.gradle
+++ b/dockerfiles/dockerfile.gradle
@@ -1,6 +1,6 @@
 ARG dockerRepository
 ARG tag
-FROM ${dockerRepository}/galasadev/galasa-wrapping:${tag}
+FROM ${dockerRepository}/galasa-dev/wrapping-maven-artefacts:${tag}
 
 COPY repo/ /usr/local/apache2/htdocs/
 COPY gradle.githash /usr/local/apache2/htdocs/gradle.githash


### PR DESCRIPTION
Updating the Dockerfile FROM and the required build arguments to use the new image containing wrapping's maven artefacts in GHCR now its available.