### PR TITLE
Add support for Gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ group   = "dev.galasa"
 
 // Note: The following line is changed by the set-version.sh script.
 // It is also read by other build scrips as required.
-version = "0.33.0"
+version = "0.36.0"
 
 signing {
     def signingKeyId = findProperty("signingKeyId")

--- a/dev.galasa.gradle.impl/build.gradle
+++ b/dev.galasa.gradle.impl/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.33.0"
+version = "0.36.0"
 
 repositories {
     mavenLocal()
@@ -33,9 +33,9 @@ tasks.withType(Javadoc) {
 }
 
 task gitHash(dependsOn : 'classes') {
-    def dir    = file("${buildDir}/githash")
-    def meta   = file("${buildDir}/githash/META-INF")
-    def result = file("${buildDir}/githash/META-INF/git.hash")
+    def dir    = layout.buildDirectory.dir("githash").get().asFile
+    def meta   = layout.buildDirectory.dir("githash/META-INF").get().asFile
+    def result = layout.buildDirectory.file("githash/META-INF/git.hash").get().asFile
     
     outputs.dir meta
     tasks.jar.dependsOn('gitHash')

--- a/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/common/GradleCompatibilityService.java
+++ b/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/common/GradleCompatibilityService.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.gradle.common;
+
+import org.gradle.util.GradleVersion;
+
+public class GradleCompatibilityService implements ICompatibilityService {
+    
+    public static final GradleVersion CURRENT_GRADLE_VERSION = GradleVersion.current();
+
+    public boolean isCurrentVersionLaterThanGradle8() {
+        return CURRENT_GRADLE_VERSION.compareTo(GradleVersion.version("8.0")) >= 0;
+    }
+}

--- a/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/common/ICompatibilityService.java
+++ b/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/common/ICompatibilityService.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.gradle.common;
+
+public interface ICompatibilityService {
+    boolean isCurrentVersionLaterThanGradle8();
+}

--- a/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/hashes/GitHashBuildTask.java
+++ b/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/hashes/GitHashBuildTask.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
+import org.gradle.api.file.Directory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
@@ -57,17 +58,15 @@ public class GitHashBuildTask extends DefaultTask {
         Jar jarTask = (Jar) getProject().getTasks().getByName("jar");
         jarTask.getDependsOn().add(this);
 
-        //*** Create the directories so Gradle does not moan
-        File dirGenTestCatalog = new File(getProject().getBuildDir(),"hashes");
-        File dirGenTestCatalogMeta = new File(dirGenTestCatalog,"META-INF");
-        //*** dont need to create the file here, just indicate where it will be on the outputs
-        this.gitHash = new File(dirGenTestCatalogMeta,"git.hash");
+        //*** Create the directories so Gradle does not moan)
+        Directory dirHashes = getProject().getLayout().getBuildDirectory().dir("hashes").get();
+        Directory dirHashesMeta = dirHashes.dir("META-INF");
+
+        this.gitHash = dirHashesMeta.file("git.hash").getAsFile();
 
         //*** Tell the JAR task we want to it to include the meta-inf and json file
-        jarTask.from(dirGenTestCatalog);
-
+        jarTask.from(dirHashes);
         //*** Mark the meta-inf file as output for caching purposes
-        getOutputs().dir(dirGenTestCatalog);
+        getOutputs().dir(dirHashes);
     }
-
 }

--- a/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/obr/ObrBuildTask.java
+++ b/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/obr/ObrBuildTask.java
@@ -12,7 +12,6 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -31,7 +30,9 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.logging.Logger;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 
 public class ObrBuildTask extends DefaultTask {
@@ -200,8 +201,8 @@ public class ObrBuildTask extends DefaultTask {
 
     public void apply() {
         // Run during apply phase, need to decide on the output file name
-        Path buildDirectory = Paths.get(project.getBuildDir().toURI());
-        this.pathObr = buildDirectory.resolve("galasa.obr");
+        Provider<RegularFile> obrFile = project.getLayout().getBuildDirectory().file("galasa.obr");
+        this.pathObr = obrFile.get().getAsFile().toPath();
         getOutputs().file(pathObr);
         
         ConfigurationContainer configurations = project.getConfigurations();

--- a/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/testcatalog/TestCatalogBuildTask.java
+++ b/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/testcatalog/TestCatalogBuildTask.java
@@ -22,6 +22,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 
 import com.google.gson.Gson;
@@ -201,7 +203,8 @@ public class TestCatalogBuildTask extends DefaultTask {
 
     public void apply() {
         // Run during apply phase, need to decide on the output file name
-        this.testCatalog = new File(getProject().getBuildDir(),"testcatalog.json");
+        Provider<RegularFile> testCatalogFile = getProject().getLayout().getBuildDirectory().file("testcatalog.json");
+        this.testCatalog = testCatalogFile.get().getAsFile();
         getOutputs().file(testCatalog);
 
         ConfigurationContainer configurations = getProject().getConfigurations();

--- a/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/tests/TestCatalogBuildTask.java
+++ b/dev.galasa.gradle.impl/src/main/java/dev/galasa/gradle/tests/TestCatalogBuildTask.java
@@ -20,6 +20,7 @@ import java.util.Map.Entry;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
+import org.gradle.api.file.Directory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
@@ -252,10 +253,10 @@ public class TestCatalogBuildTask extends DefaultTask {
         jarTask.getDependsOn().add(this);
 
         //*** Create the directories so Gradle does not moan
-        File dirGenTestCatalog = new File(getProject().getBuildDir(),"gentestcatalog");
-        File dirGenTestCatalogMeta = new File(dirGenTestCatalog,"META-INF");
+        Directory dirGenTestCatalog = getProject().getLayout().getBuildDirectory().dir("gentestcatalog").get();
+        Directory dirGenTestCatalogMeta = dirGenTestCatalog.dir("META-INF");
         //*** dont need to create the file here, just indicate where it will be on the outputs
-        this.testCatalog = new File(dirGenTestCatalogMeta,"testcatalog.json");
+        this.testCatalog = dirGenTestCatalogMeta.file("testcatalog.json").getAsFile();
 
         //*** Tell the JAR task we want to it to include the meta-inf and json file
         jarTask.from(dirGenTestCatalog);

--- a/dev.galasa.plugin.common.impl/build.gradle
+++ b/dev.galasa.plugin.common.impl/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.33.0"
+version = "0.36.0"
 
 repositories {
     maven {

--- a/dev.galasa.plugin.common.test/build.gradle
+++ b/dev.galasa.plugin.common.test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.33.0"
+version = "0.36.0"
 
 repositories {
     maven {

--- a/dev.galasa.plugin.common/build.gradle
+++ b/dev.galasa.plugin.common/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.33.0"
+version = "0.36.0"
 
 repositories {
     maven {
@@ -31,9 +31,9 @@ tasks.withType(Javadoc) {
 }
 
 task gitHash(dependsOn : 'classes') {
-    def dir    = file("${buildDir}/githash")
-    def meta   = file("${buildDir}/githash/META-INF")
-    def result = file("${buildDir}/githash/META-INF/git.hash")
+    def dir    = layout.buildDirectory.dir("githash").get().asFile
+    def meta   = layout.buildDirectory.dir("githash/META-INF").get().asFile
+    def result = layout.buildDirectory.file("githash/META-INF/git.hash").get().asFile
     
     outputs.dir meta
     tasks.jar.dependsOn('gitHash')


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1652

Fixes build errors when building Galasa's gradle plugins using Gradle 8 (tested on Gradle 8.9), while also continuing to support the use of Gradle 6 and 7 (tested on 6.8.2 and 7.5.1).