### PR TITLE
Add trigger for maven with GH CLI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,3 +89,15 @@ jobs:
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
           docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait gh-maven-repos --resource apps:Deployment:gradle-gh --health --server argocd.galasa.dev
+
+  trigger-maven-workflow:
+    name: Trigger Maven workflow
+    runs-on: ubuntu-latest
+    needs: build-gradle 
+
+    steps:
+      - name: Trigger Maven workflow dispatch event with GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/maven


### PR DESCRIPTION
## Why?

For issue https://github.com/galasa-dev/projectmanagement/issues/1950 joining the core build chain together. Using the GH CLI as using GitHub's built in "reusable workflow" concept nests the workflows inside eachother instead of just calling the next once one is done.