### PR TITLE
Add workflow dispatch inputs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,23 @@ name: Main build
 
 on:
   workflow_dispatch:
+    inputs:
+      jacocoEnabled:
+        description: 'Enable Jacoco code coverage (set to "false" for release builds)'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
+      isMainOrRelease:
+        description: 'This build is for the main branch or a release (set to "false" for development branch builds)'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
   push:
     branches: [main]
 


### PR DESCRIPTION
## Why?

Needed because of changes in https://github.com/galasa-dev/wrapping/pull/85
The wrapping workflow triggers the gradle workflow using the workflow_dispatch event so needs the input fields specified so the trigger doesnt fail. We can parameterise this workflow at a later date.