### PR TITLE
Parameterise gradle workflow to support other branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,8 +26,17 @@ env:
   REGISTRY: ghcr.io
   NAMESPACE: galasa-dev
   BRANCH: ${{ github.ref_name }}
+  ARGO_APP_BRANCH: gh # TODO: remove this parameter and just use env.BRANCH once we update development.galasa.dev/main with these workflows.
 
 jobs:
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
   build-gradle:
     name: Build Gradle source code and Docker image for development Maven registry
     runs-on: ubuntu-latest
@@ -52,6 +61,7 @@ jobs:
           gradle-version: 6.9.2
 
       - name: Build Gradle source code
+        if: github.event_name == 'push'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
@@ -64,6 +74,21 @@ jobs:
           -PtargetMaven=${{ github.workspace }}/repo \
           -PjacocoEnabled=true \
           -PisMainOrRelease=true
+
+      - name: Build Gradle source code
+        if: github.event_name == 'workflow_dispatch' # Use the input values provided by the workflow dispatch.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          gradle check publish \
+          -PsourceMaven=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/wrapping \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/repo \
+          -PjacocoEnabled=${{ inputs.jacocoEnabled }} \
+          -PisMainOrRelease=${{ inputs.isMainOrRelease }}
           
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
@@ -98,14 +123,14 @@ jobs:
         env: 
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run gh-maven-repos restart --kind Deployment --resource-name gradle-gh --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.ARGO_APP_BRANCH }}-maven-repos restart --kind Deployment --resource-name gradle-${{ env.ARGO_APP_BRANCH }} --server argocd.galasa.dev
 
       # Wait for the application to show as healthy in ArgoCD
       - name: Wait for app health in ArgoCD
         env: 
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait gh-maven-repos --resource apps:Deployment:gradle-gh --health --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.ARGO_APP_BRANCH }}-maven-repos --resource apps:Deployment:gradle-${{ env.ARGO_APP_BRANCH }} --health --server argocd.galasa.dev
 
   trigger-maven-workflow:
     name: Trigger Maven workflow
@@ -114,7 +139,15 @@ jobs:
 
     steps:
       - name: Trigger Maven workflow dispatch event with GitHub CLI
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
           gh workflow run build.yaml --repo https://github.com/galasa-dev/maven
+      
+      - name: Trigger Maven workflow dispatch event with GitHub CLI
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/maven --ref ${{ env.BRANCH }} -f jacocoEnabled=${{ inputs.jacocoEnabled }} -f isMainOrRelease=${{ inputs.isMainOrRelease }}


### PR DESCRIPTION
## Why?

Contributes to issue https://github.com/galasa-dev/projectmanagement/issues/1958 - parameterising the build workflow to support any branch/tag.